### PR TITLE
Adjust mega-menu max height and search bar width

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -10255,3 +10255,23 @@ initTheme();
 }();
 /******/ })()
 ;
+
+(function(){
+  const mql=window.matchMedia('(min-width:1024px)');
+  const header=document.querySelector('.header__wrapper');
+  const trigger=document.querySelector('.sf-menu-item-parent[data-mega="categorii"]');
+  if(!header||!trigger) return;
+
+  function setMegaMaxHeight(){
+    if(!mql.matches) return;
+    const bottom=header.getBoundingClientRect().bottom||0;
+    const padding=24;
+    const maxH=Math.max(240,window.innerHeight-Math.ceil(bottom)-padding);
+    document.documentElement.style.setProperty('--eg-mega-max-h',`${maxH}px`);
+  }
+
+  ['resize','orientationchange'].forEach(evt=>window.addEventListener(evt,setMegaMaxHeight,{passive:true}));
+  document.addEventListener('DOMContentLoaded',setMegaMaxHeight);
+  trigger.addEventListener('mouseenter',setMegaMaxHeight);
+  trigger.addEventListener('focusin',setMegaMaxHeight);
+})();

--- a/assets/theme.css
+++ b/assets/theme.css
@@ -6,10 +6,19 @@
     max-width:1200px;
     margin:0 auto;
   }
+  .sf-header .sf-menu-item-parent[data-mega="categorii"] .sf-menu__submenu,
+  .sf-header .sf-menu-item-parent[data-mega="categorii"] .sf-menu__desktop-sub-menu,
+  .sf-header .sf-menu-item-parent[data-mega="categorii"] .sf-menu__inner{
+    overflow:visible;
+  }
   .sf-header .sf-menu-item-parent[data-mega="categorii"] .sf-menu-submenu__content{
-    max-height:calc(100vh - 140px);
-    overflow-y:auto;
+    box-sizing:border-box;
     padding:2rem;
+    padding-bottom:24px;
+    overscroll-behavior:contain;
+    scrollbar-gutter:stable both-edges;
+    max-height:var(--eg-mega-max-h,calc(100vh - 140px));
+    overflow-y:auto;
     border:1px solid #e5e5e5;
     box-shadow:0 6px 12px rgba(0,0,0,.08);
     background:#fff;
@@ -35,5 +44,9 @@
   }
   .sf-header .sf-menu-item-parent[data-mega="categorii"] .sf__sub-menu-column a:hover{
     text-decoration:underline;
+  }
+  .sf-header.sf-mega-active .sf-search-form{
+    flex:0 0 auto;
+    width:auto;
   }
 }


### PR DESCRIPTION
## Summary
- compute dynamic `--eg-mega-max-h` for "Categorii" mega-menu and prevent scrollbar clipping
- keep desktop search bar width stable when mega menu is active

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b44834f0832da8a284f7e8e16dcc