### PR TITLE
Use gray subcategory link color for desktop menu

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -39,11 +39,14 @@
     display:block;
   }
   .sf-header .sf-menu-item-parent[data-mega="categorii"] .sf__sub-menu-column a{
-    color:#0654ba;
     font-size:14px;
+    color: var(--color-sub-text, #666);
+    text-decoration: none;
   }
-  .sf-header .sf-menu-item-parent[data-mega="categorii"] .sf__sub-menu-column a:hover{
-    text-decoration:underline;
+  .sf-header .sf-menu-item-parent[data-mega="categorii"] .sf__sub-menu-column a:hover,
+  .sf-header .sf-menu-item-parent[data-mega="categorii"] .sf__sub-menu-column a:focus{
+    color: var(--color-sub-text, #666);
+    text-decoration: underline;
   }
   .sf-header.sf-mega-active .sf-search-form{
     flex:0 0 auto;


### PR DESCRIPTION
## Summary
- ensure `data-mega="categorii"` subcategory links use gray text and proper text decoration

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5beb2d238832d9d4fdad49416019d