### PR TITLE
Ensure search bar stays visible when mega menu opens

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -52,4 +52,6 @@
     flex:0 0 auto;
     width:auto;
   }
+  .sf-search-form{flex-shrink:0;min-width:220px;}
+  .sf-header .sf-menu-item:hover~.sf-search-form{opacity:1;width:auto;}
 }

--- a/snippets/header-option-item__search.liquid
+++ b/snippets/header-option-item__search.liquid
@@ -2,7 +2,7 @@
 
 {% unless search_display == 'hide' %}
     <div
-      class="sf-search-form flex items-center{% if icon_left == true %} pr-4{% endif %} {{ box_size }} {%- if search_display == 'show_full' -%} sf-search-form--full border border-color-border hover:border-gray-400 rounded-md{%- endif -%}"
+      class="sf-search-form flex items-center flex-shrink-0 w-[220px]{% if icon_left == true %} pr-4{% endif %} {{ box_size }} {%- if search_display == 'show_full' -%} sf-search-form--full border border-color-border hover:border-gray-400 rounded-md{%- endif -%}"
       data-open-search-popup
     >
       {% if icon_left == true %}


### PR DESCRIPTION
## Summary
- Prevent menu hover from hiding the search form and enforce a minimum width
- Keep header search form from shrinking via flex-shrink and width utilities

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ee556878832dafc36e74c85be931