### PR TITLE
Header mega-menu: decouple hover vs click state (.mega-open)

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -3372,6 +3372,7 @@ class SiteNav {
     });
 
     _defineProperty(this, "onMenuItemEnter", (evt, index) => {
+      if (this.container?.classList.contains('mega-open')) return;
       const {
         target
       } = evt;
@@ -3398,6 +3399,7 @@ class SiteNav {
     });
 
     _defineProperty(this, "onMenuItemLeave", (evt, index) => {
+      if (this.container?.classList.contains('mega-open')) return;
       // console.log(evt, 'leave')
       this.activeIndex = -1;
       this.lastActiveIndex = index;
@@ -10286,21 +10288,18 @@ initTheme();
   const item=trigger.closest('.sf-menu-item');
   const panel=item?item.querySelector('.sf-menu__submenu'):null;
   let isOpen=false;
-
-  // Prevent default hover handlers from SiteNav
-  const stopHover=e=>e.stopImmediatePropagation();
-  item.addEventListener('mouseenter',stopHover,true);
-  item.addEventListener('mouseleave',stopHover,true);
+  let closeTimer;
 
   // Open/close helpers
   const openMenu=()=>{
     isOpen=true;
-    header.classList.add('sf-mega-active');
+    header.classList.add('mega-open','sf-mega-active');
+    document.querySelectorAll('.sf-menu-item--active').forEach(el=>{el!==item&&el.classList.remove('sf-menu-item--active');});
     item.classList.add('sf-menu-item--active');
   };
   const closeMenu=()=>{
     isOpen=false;
-    header.classList.remove('sf-mega-active');
+    header.classList.remove('mega-open','sf-mega-active');
     item.classList.remove('sf-menu-item--active');
   };
 
@@ -10311,28 +10310,19 @@ initTheme();
     isOpen?closeMenu():openMenu();
   });
 
-  // Close when mouse leaves both trigger and panel
-  const handleLeave=e=>{
-    const rel=e.relatedTarget;
-    if(!trigger.contains(rel)&&!(panel&&panel.contains(rel))){
-      closeMenu();
-    }
+  // Debounced close when mouse leaves both trigger and panel
+  const startClose=()=>{
+    closeTimer=setTimeout(()=>{
+      if(!trigger.matches(':hover')&&!(panel&&panel.matches(':hover'))){
+        closeMenu();
+      }
+    },120);
   };
-  trigger.addEventListener('mouseleave',handleLeave);
-  panel&&panel.addEventListener('mouseleave',handleLeave);
+  const cancelClose=()=>clearTimeout(closeTimer);
+  [trigger,panel].forEach(el=>{el&&el.addEventListener('mouseenter',cancelClose);});
+  [trigger,panel].forEach(el=>{el&&el.addEventListener('mouseleave',startClose);});
 
-  // Accessibility: close on Escape key
-  document.addEventListener('keydown',e=>{
-    if(e.key==='Escape'&&isOpen) closeMenu();
-  });
-
-  // Close if focus leaves both trigger and panel
-  const handleFocusOut=e=>{
-    const rel=e.relatedTarget;
-    if(!trigger.contains(rel)&&!(panel&&panel.contains(rel))){
-      closeMenu();
-    }
-  };
-  trigger.addEventListener('focusout',handleFocusOut);
-  panel&&panel.addEventListener('focusout',handleFocusOut);
+  // Close on Escape key or when leaving desktop breakpoint
+  document.addEventListener('keydown',e=>{if(e.key==='Escape')closeMenu();});
+  mql.addEventListener('change',e=>{if(!e.matches)closeMenu();});
 })();

--- a/assets/custom.css
+++ b/assets/custom.css
@@ -201,3 +201,25 @@
     display: none;
   }
 }
+
+@media (min-width: 1024px) {
+  /* keep header search visible when mega menu opens via click */
+  .sf-header .sf-search-form {
+    flex-shrink: 0;
+    min-width: var(--search-min, 260px);
+    position: relative;
+    z-index: 1001;
+  }
+  .sf-header.mega-open {
+    overflow: visible;
+  }
+  .sf-header.mega-open .sf-search-form {
+    opacity: 1;
+    visibility: visible;
+    width: auto;
+  }
+  .sf-header:not(.mega-open).sf-mega-active .sf-search-form {
+    flex: 0 0 auto;
+    width: auto;
+  }
+}

--- a/assets/custom.css.liquid
+++ b/assets/custom.css.liquid
@@ -202,3 +202,25 @@
     display: none;
   }
 }
+
+@media (min-width: 1024px) {
+  /* keep header search visible when mega menu opens via click */
+  .sf-header .sf-search-form {
+    flex-shrink: 0;
+    min-width: var(--search-min, 260px);
+    position: relative;
+    z-index: 1001;
+  }
+  .sf-header.mega-open {
+    overflow: visible;
+  }
+  .sf-header.mega-open .sf-search-form {
+    opacity: 1;
+    visibility: visible;
+    width: auto;
+  }
+  .sf-header:not(.mega-open).sf-mega-active .sf-search-form {
+    flex: 0 0 auto;
+    width: auto;
+  }
+}


### PR DESCRIPTION
## Summary
- Decouple hover vs click behaviour for the "Categorii" mega-menu via new `.mega-open` state
- Keep header search form visible and stable while mega menu is open
- Close click-open mega menu on mouseleave with debounce, escape key, or viewport resize

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f2a29474832db1f0ba66bb4cad53