### PR TITLE
feat: click-triggered mega menu for Categorii

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -3361,6 +3361,9 @@ class SiteNav {
 
     _defineProperty(this, "attachEvents", () => {
       this.domNodes.menuItems.forEach((menuItem, index) => {
+        // Skip default hover handlers for the "Categorii" mega menu; it will be
+        // controlled via custom click logic elsewhere.
+        if (menuItem.matches('.sf-menu-item-parent[data-mega="categorii"]')) return;
         menuItem.addEventListener('mouseenter', evt => this.onMenuItemEnter(evt, index));
         menuItem.addEventListener('mouseleave', evt => this.onMenuItemLeave(evt, index));
       });
@@ -10321,6 +10324,13 @@ initTheme();
   const cancelClose=()=>clearTimeout(closeTimer);
   [trigger,panel].forEach(el=>{el&&el.addEventListener('mouseenter',cancelClose);});
   [trigger,panel].forEach(el=>{el&&el.addEventListener('mouseleave',startClose);});
+
+  // Close if trigger loses focus and the new focus is outside the panel
+  trigger.addEventListener('focusout',e=>{
+    if(!panel||!panel.contains(e.relatedTarget)){
+      closeMenu();
+    }
+  });
 
   // Close on Escape key or when leaving desktop breakpoint
   document.addEventListener('keydown',e=>{if(e.key==='Escape')closeMenu();});

--- a/assets/custom.css
+++ b/assets/custom.css
@@ -208,7 +208,8 @@
     flex-shrink: 0;
     min-width: var(--search-min, 260px);
     position: relative;
-    z-index: 1001;
+    /* Ensure search bar stays above mega menu */
+    z-index: 1100;
   }
   .sf-header.mega-open {
     overflow: visible;
@@ -221,5 +222,13 @@
   .sf-header:not(.mega-open).sf-mega-active .sf-search-form {
     flex: 0 0 auto;
     width: auto;
+  }
+}
+
+@media (min-width: 1024px) {
+  /* Rounded bottom corners on scrollable Categorii mega menu panel */
+  .sf-header .sf-menu-item-parent[data-mega="categorii"] .sf-menu-submenu__content {
+    border-bottom-left-radius: 5px;
+    border-bottom-right-radius: 5px;
   }
 }

--- a/assets/custom.css.liquid
+++ b/assets/custom.css.liquid
@@ -203,24 +203,32 @@
   }
 }
 
-@media (min-width: 1024px) {
-  /* keep header search visible when mega menu opens via click */
-  .sf-header .sf-search-form {
-    flex-shrink: 0;
-    min-width: var(--search-min, 260px);
-    position: relative;
-    z-index: 1001;
+  @media (min-width: 1024px) {
+    /* keep header search visible when mega menu opens via click */
+    .sf-header .sf-search-form {
+      flex-shrink: 0;
+      min-width: var(--search-min, 260px);
+      position: relative;
+      /* Ensure search bar stays above mega menu */
+      z-index: 1100;
+    }
+    .sf-header.mega-open {
+      overflow: visible;
+    }
+    .sf-header.mega-open .sf-search-form {
+      opacity: 1;
+      visibility: visible;
+      width: auto;
+    }
+    .sf-header:not(.mega-open).sf-mega-active .sf-search-form {
+      flex: 0 0 auto;
+      width: auto;
+    }
   }
-  .sf-header.mega-open {
-    overflow: visible;
+  @media (min-width: 1024px) {
+    /* Rounded bottom corners on scrollable Categorii mega menu panel */
+    .sf-header .sf-menu-item-parent[data-mega="categorii"] .sf-menu-submenu__content {
+      border-bottom-left-radius: 5px;
+      border-bottom-right-radius: 5px;
+    }
   }
-  .sf-header.mega-open .sf-search-form {
-    opacity: 1;
-    visibility: visible;
-    width: auto;
-  }
-  .sf-header:not(.mega-open).sf-mega-active .sf-search-form {
-    flex: 0 0 auto;
-    width: auto;
-  }
-}


### PR DESCRIPTION
## Summary
- handle `data-mega="categorii"` using click toggle rather than hover
- skip default hover handlers for Categorii item
- ensure search form stays above mega menu with higher z-index
- round bottom corners of the scrollable Categorii mega panel for a softer finish

## Testing
- `npm test` *(fails: could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68a6060dfa28832daf355728af2bb28f