### PR TITLE
feat: click-triggered mega menu for Categorii

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -3361,6 +3361,9 @@ class SiteNav {
 
     _defineProperty(this, "attachEvents", () => {
       this.domNodes.menuItems.forEach((menuItem, index) => {
+        // Skip default hover handlers for the "Categorii" mega menu; it will be
+        // controlled via custom click logic elsewhere.
+        if (menuItem.matches('.sf-menu-item-parent[data-mega="categorii"]')) return;
         menuItem.addEventListener('mouseenter', evt => this.onMenuItemEnter(evt, index));
         menuItem.addEventListener('mouseleave', evt => this.onMenuItemLeave(evt, index));
       });
@@ -10321,6 +10324,13 @@ initTheme();
   const cancelClose=()=>clearTimeout(closeTimer);
   [trigger,panel].forEach(el=>{el&&el.addEventListener('mouseenter',cancelClose);});
   [trigger,panel].forEach(el=>{el&&el.addEventListener('mouseleave',startClose);});
+
+  // Close if trigger loses focus and the new focus is outside the panel
+  trigger.addEventListener('focusout',e=>{
+    if(!panel||!panel.contains(e.relatedTarget)){
+      closeMenu();
+    }
+  });
 
   // Close on Escape key or when leaving desktop breakpoint
   document.addEventListener('keydown',e=>{if(e.key==='Escape')closeMenu();});

--- a/assets/custom.css
+++ b/assets/custom.css
@@ -208,7 +208,8 @@
     flex-shrink: 0;
     min-width: var(--search-min, 260px);
     position: relative;
-    z-index: 1001;
+    /* Ensure search bar stays above mega menu */
+    z-index: 1100;
   }
   .sf-header.mega-open {
     overflow: visible;
@@ -221,5 +222,13 @@
   .sf-header:not(.mega-open).sf-mega-active .sf-search-form {
     flex: 0 0 auto;
     width: auto;
+  }
+}
+
+@media (min-width: 1024px) {
+  /* Rounded bottom corners on scrollable Categorii mega menu panel */
+  .sf-header .sf-menu-item-parent[data-mega="categorii"] .sf-menu-submenu__content {
+    border-bottom-left-radius: 5px;
+    border-bottom-right-radius: 5px;
   }
 }

--- a/assets/custom.css.liquid
+++ b/assets/custom.css.liquid
@@ -203,24 +203,32 @@
   }
 }
 
-@media (min-width: 1024px) {
-  /* keep header search visible when mega menu opens via click */
-  .sf-header .sf-search-form {
-    flex-shrink: 0;
-    min-width: var(--search-min, 260px);
-    position: relative;
-    z-index: 1001;
+  @media (min-width: 1024px) {
+    /* keep header search visible when mega menu opens via click */
+    .sf-header .sf-search-form {
+      flex-shrink: 0;
+      min-width: var(--search-min, 260px);
+      position: relative;
+      /* Ensure search bar stays above mega menu */
+      z-index: 1100;
+    }
+    .sf-header.mega-open {
+      overflow: visible;
+    }
+    .sf-header.mega-open .sf-search-form {
+      opacity: 1;
+      visibility: visible;
+      width: auto;
+    }
+    .sf-header:not(.mega-open).sf-mega-active .sf-search-form {
+      flex: 0 0 auto;
+      width: auto;
+    }
   }
-  .sf-header.mega-open {
-    overflow: visible;
+  @media (min-width: 1024px) {
+    /* Rounded bottom corners on scrollable Categorii mega menu panel */
+    .sf-header .sf-menu-item-parent[data-mega="categorii"] .sf-menu-submenu__content {
+      border-bottom-left-radius: 5px;
+      border-bottom-right-radius: 5px;
+    }
   }
-  .sf-header.mega-open .sf-search-form {
-    opacity: 1;
-    visibility: visible;
-    width: auto;
-  }
-  .sf-header:not(.mega-open).sf-mega-active .sf-search-form {
-    flex: 0 0 auto;
-    width: auto;
-  }
-}

--- a/templates/list-collections.json
+++ b/templates/list-collections.json
@@ -1,1 +1,77 @@
-{"sections":{"main":{"type":"collection-list-template","blocks":{"06786fde-900d-4048-b2a7-2f1af4b4963e":{"type":"collection_item","settings":{"collection":"sweaters"}},"c3c7dd10-c393-458e-a903-3de238b2e424":{"type":"collection_item","settings":{"collection":"leather-boots"}},"b43bcd47-6305-4507-86b2-397dcbb3cdfc":{"type":"collection_item","settings":{"collection":"denim-pants"}},"17b453d1-b173-4aed-8571-7dc75d2ec6ca":{"type":"collection_item","settings":{"collection":"sunglasses"}},"3aedbb94-935a-4d80-865f-7c7fbbbddb39":{"type":"collection_item","settings":{"collection":"leather-bag"}}},"block_order":["06786fde-900d-4048-b2a7-2f1af4b4963e","c3c7dd10-c393-458e-a903-3de238b2e424","b43bcd47-6305-4507-86b2-397dcbb3cdfc","17b453d1-b173-4aed-8571-7dc75d2ec6ca","3aedbb94-935a-4d80-865f-7c7fbbbddb39"],"settings":{"container":"container-fluid","display_type":"all","title":"Toate Categoriile","description":"<p>Descopera intr-un singur loc toate categoriile disponibile pe Egross. De la articole pentru casa, gradina si sport, pana la jucarii, imbracaminte si decoratiuni – gasesti tot ce ai nevoie la preturi corecte si cu livrare rapida.<\/p>"}}},"order":["main"]}
+/*
+ * ------------------------------------------------------------
+ * IMPORTANT: The contents of this file are auto-generated.
+ *
+ * This file may be updated by the Shopify admin theme editor
+ * or related systems. Please exercise caution as any changes
+ * made to this file may be overwritten.
+ * ------------------------------------------------------------
+ */
+{
+  "sections": {
+    "main": {
+      "type": "collection-list-template",
+      "blocks": {
+        "06786fde-900d-4048-b2a7-2f1af4b4963e": {
+          "type": "collection_item",
+          "disabled": true,
+          "settings": {
+            "collection": "sweaters"
+          }
+        },
+        "collection_item_Ra7mhb": {
+          "type": "collection_item",
+          "disabled": true,
+          "settings": {
+            "collection": ""
+          }
+        },
+        "c3c7dd10-c393-458e-a903-3de238b2e424": {
+          "type": "collection_item",
+          "disabled": true,
+          "settings": {
+            "collection": "leather-boots"
+          }
+        },
+        "b43bcd47-6305-4507-86b2-397dcbb3cdfc": {
+          "type": "collection_item",
+          "disabled": true,
+          "settings": {
+            "collection": "denim-pants"
+          }
+        },
+        "17b453d1-b173-4aed-8571-7dc75d2ec6ca": {
+          "type": "collection_item",
+          "disabled": true,
+          "settings": {
+            "collection": "sunglasses"
+          }
+        },
+        "3aedbb94-935a-4d80-865f-7c7fbbbddb39": {
+          "type": "collection_item",
+          "disabled": true,
+          "settings": {
+            "collection": "leather-bag"
+          }
+        }
+      },
+      "block_order": [
+        "06786fde-900d-4048-b2a7-2f1af4b4963e",
+        "collection_item_Ra7mhb",
+        "c3c7dd10-c393-458e-a903-3de238b2e424",
+        "b43bcd47-6305-4507-86b2-397dcbb3cdfc",
+        "17b453d1-b173-4aed-8571-7dc75d2ec6ca",
+        "3aedbb94-935a-4d80-865f-7c7fbbbddb39"
+      ],
+      "settings": {
+        "container": "container-fluid",
+        "display_type": "all",
+        "title": "Toate Categoriile",
+        "description": "<p>Descopera intr-un singur loc toate categoriile disponibile pe Egross. De la articole pentru casa, gradina si sport, pana la jucarii, imbracaminte si decoratiuni – gasesti tot ce ai nevoie la preturi corecte si cu livrare rapida.</p>"
+      }
+    }
+  },
+  "order": [
+    "main"
+  ]
+}


### PR DESCRIPTION
## Summary
- handle `data-mega="categorii"` using click toggle rather than hover
- skip default hover handlers for Categorii item
- ensure search form stays above mega menu with higher z-index
- round bottom corners of the scrollable Categorii mega panel for a softer finish

## Testing
- `npm test` *(fails: could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68a6060dfa28832daf355728af2bb28f