### PR TITLE
Rotate Categorii menu arrow on click

### DIFF
--- a/assets/custom.css.liquid
+++ b/assets/custom.css.liquid
@@ -234,3 +234,19 @@
   }
 }
 
+@media (min-width: 1024px) {
+  /* Rotate arrow for "Categorii" only when menu is open */
+  .sf-menu-item-parent[data-mega="categorii"] > a .sf-menu__arrow svg {
+    transition: transform 0.3s ease;
+    transform: rotate(0deg);
+  }
+
+  .sf-menu-item-parent[data-mega="categorii"]:hover > a .sf-menu__arrow svg {
+    transform: rotate(0deg) !important;
+  }
+
+  .sf-menu-item-parent[data-mega="categorii"].sf-menu-item--active > a .sf-menu__arrow svg {
+    transform: rotate(180deg) !important;
+  }
+}
+


### PR DESCRIPTION
## Summary
- Rotate the "Categorii" menu arrow only when the menu is open via click
- Prevent arrow rotation on hover and restore orientation when menu closes

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/egross-13/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68a61285ad70832daea9cef1aacbe68b