### PR TITLE
Mega Categorii: group utility links into single column

### DIFF
--- a/snippets/header-main-menu-container.liquid
+++ b/snippets/header-main-menu-container.liquid
@@ -260,7 +260,25 @@
                                 <div class="{% if is_mega %}{{ dropdown_container | default: 'container' }}{% endif %} mx-auto{% if dropdown_container == 'w-full' %} px-5{% endif %}">
                                     <div class="sf-menu-submenu__content{% if stretch_width == true %} sf-menu-submenu--stretch-width{% endif %} flex{% if is_mega == false %} p-4 {% else %} py-12{% endif %}">
                                         <ul class="sf-menu-submenu__items flex {% if is_mega == false %} flex-col w-full{% else %} -mx-2{% if stretch_width == false and block_type != blank %} w-2/3{% else %} w-full{% endif %}{% endif %}">
+                                            {% if title_handle == 'categorii' %}
+                                                {% assign utility_handles = 'promotii,lichidare-de-stoc,toate-produsele,toate-categoriile' | split: ',' %}
+                                                {% capture utility_column %}{% endcapture %}
+                                            {% endif %}
                                             {% for childlink in link.links %}
+                                                {% if title_handle == 'categorii' %}
+                                                    {% assign h = childlink.title | handleize %}
+                                                    {% if utility_handles contains h %}
+                                                        {% capture utility_column %}
+                                                            {{ utility_column }}
+                                                            <li class="list-none sf__menu-item-level2 mb-4" data-utility="true">
+                                                                <a href="{{ childlink.url }}" class="sf__sub-menu-link2 whitespace-normal block sf-menu-submenu__title">
+                                                                    {{ childlink.title }}
+                                                                </a>
+                                                            </li>
+                                                        {% endcapture %}
+                                                        {% continue %}
+                                                    {% endif %}
+                                                {% endif %}
                                                 <li class="list-none sf__menu-item-level2 {% if is_mega %} w-1/2 xl:w-1/3 2xl:w-1/4 mb-4{% else %} w-full leading-9{% endif %}{% if stretch_width == true %} min-w-[200px] pr-2{% endif %}">
                                                     <a href="{{ childlink.url }}" class="sf__sub-menu-link2 whitespace-normal block{% if is_mega %} sf-menu-submenu__title{% else %} sf-sub-menu__link{% endif %}">{{ childlink.title }}</a>
                                                     {% if childlink.links != blank %}
@@ -278,6 +296,13 @@
                                                     {% endif %}
                                                 </li>
                                             {% endfor %}
+                                            {% if title_handle == 'categorii' and utility_column != '' %}
+                                                <li class="list-none sf__menu-item-level2 w-1/2 xl:w-1/3 2xl:w-1/4 mb-4 is-utilities">
+                                                    <ul class="sf-menu-submenu__items--utilities m-0 p-0 list-none">
+                                                        {{ utility_column }}
+                                                    </ul>
+                                                </li>
+                                            {% endif %}
                                         </ul>
                                         {% if has_mega_item == true and block_type != blank %}
                                             <div class="sf-menu-submenu__addon pl-5{% if stretch_width == false %} w-1/3{% endif %}">


### PR DESCRIPTION
## Summary
- Consolidate 'Promotii', 'Lichidare de stoc', 'Toate Produsele', and 'Toate Categoriile' into one dedicated column in the 'Categorii' mega menu with title styling.

## Testing
- `npx @shopify/theme-check@latest .` *(fails: package not found)*
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a61b1f09b4832db3933a58a5d3f471