### PR TITLE
Allow mega menu link navigation

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -10307,10 +10307,15 @@ initTheme();
   };
 
   // Toggle on click of trigger
-  trigger.addEventListener('click',e=>{
-    if(!mql.matches) return;
-    e.preventDefault();
-    isOpen?closeMenu():openMenu();
+  trigger.addEventListener('click', e => {
+    if (!mql.matches) return;
+    if (!isOpen) {
+      e.preventDefault();
+      openMenu();
+    } else {
+      // Allow navigation on second click while ensuring menu state resets
+      closeMenu();
+    }
   });
 
   // Debounced close when mouse leaves both trigger and panel


### PR DESCRIPTION
## Summary
- allow mega menu trigger link to navigate by only preventing default on first click

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a62510eff0832d97338cdd032d0837