### PR TITLE
Fix mega menu column overflow on desktop

### DIFF
--- a/assets/custom.css.liquid
+++ b/assets/custom.css.liquid
@@ -250,3 +250,30 @@
   }
 }
 
+@media (min-width: 1024px) {
+  /* Mega menu columns: prevent overflow and enforce grid layout */
+  .sf-menu-submenu__content,
+  .sf-menu-submenu__items,
+  .sf-menu-submenu__items > li {
+    box-sizing: border-box;
+  }
+
+  .sf-menu-submenu__items {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(var(--column-width, 220px), 1fr));
+    gap: 1.5rem;
+    margin-left: 0;
+    margin-right: 0;
+  }
+
+  .sf-menu-submenu__items > li {
+    width: auto !important;
+    min-width: 0;
+  }
+
+  .sf-menu__submenu {
+    width: 100%;
+    overflow-x: hidden;
+  }
+}
+

--- a/snippets/header-main-menu-container.liquid
+++ b/snippets/header-main-menu-container.liquid
@@ -259,7 +259,7 @@
                             <div class="sf-menu__inner">
                                 <div class="{% if is_mega %}{{ dropdown_container | default: 'container' }}{% endif %} mx-auto{% if dropdown_container == 'w-full' %} px-5{% endif %}">
                                     <div class="sf-menu-submenu__content{% if stretch_width == true %} sf-menu-submenu--stretch-width{% endif %} flex{% if is_mega == false %} p-4 {% else %} py-12{% endif %}">
-                                        <ul class="sf-menu-submenu__items flex {% if is_mega == false %} flex-col w-full{% else %} -mx-2{% if stretch_width == false and block_type != blank %} w-2/3{% else %} w-full{% endif %}{% endif %}">
+                                        <ul class="sf-menu-submenu__items{% if is_mega == false %} w-full{% else %}{% if stretch_width == false and block_type != blank %} w-2/3{% else %} w-full{% endif %}{% endif %}">
                                             {% if title_handle == 'categorii' %}
                                                 {% assign utility_handles = 'promotii,lichidare-de-stoc,toate-produsele,toate-categoriile' | split: ',' %}
                                                 {% capture utility_column %}{% endcapture %}
@@ -270,7 +270,7 @@
                                                     {% if utility_handles contains h %}
                                                         {% capture utility_column %}
                                                             {{ utility_column }}
-                                                            <li class="list-none sf__menu-item-level2 mb-4" data-utility="true">
+                                                            <li class="list-none sf__menu-item-level2 mb-4 box-border" data-utility="true">
                                                                 <a href="{{ childlink.url }}" class="sf__sub-menu-link2 whitespace-normal block sf-menu-submenu__title">
                                                                     {{ childlink.title }}
                                                                 </a>
@@ -279,7 +279,7 @@
                                                         {% continue %}
                                                     {% endif %}
                                                 {% endif %}
-                                                <li class="list-none sf__menu-item-level2 {% if is_mega %} w-1/2 xl:w-1/3 2xl:w-1/4 mb-4{% else %} w-full leading-9{% endif %}{% if stretch_width == true %} min-w-[200px] pr-2{% endif %}">
+                                                <li class="list-none sf__menu-item-level2 {% if is_mega %} mb-4 box-border{% else %} w-full leading-9{% endif %}{% if stretch_width == true %} min-w-[200px] pr-2{% endif %}">
                                                     <a href="{{ childlink.url }}" class="sf__sub-menu-link2 whitespace-normal block{% if is_mega %} sf-menu-submenu__title{% else %} sf-sub-menu__link{% endif %}">{{ childlink.title }}</a>
                                                     {% if childlink.links != blank %}
                                                         <div class="sf__sub-menu-column mt-4">
@@ -297,7 +297,7 @@
                                                 </li>
                                             {% endfor %}
                                             {% if title_handle == 'categorii' and utility_column != '' %}
-                                                <li class="list-none sf__menu-item-level2 w-1/2 xl:w-1/3 2xl:w-1/4 mb-4 is-utilities">
+                                                <li class="list-none sf__menu-item-level2 mb-4 box-border is-utilities">
                                                     <ul class="sf-menu-submenu__items--utilities m-0 p-0 list-none">
                                                         {{ utility_column }}
                                                     </ul>


### PR DESCRIPTION
## Summary
- remove negative margins and flex from mega menu columns; rely on grid and add box-sizing to column items
- add desktop CSS to enforce grid layout and constrain submenu width

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a631dc8264832da979f2c0ff6c395a