### PR TITLE
Align submenu and container widths

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -53,3 +53,12 @@
     width:auto;
   }
 }
+.container,
+.sf-menu__submenu {
+  max-width: var(--container-max);
+}
+
+.sf-menu__submenu {
+  overflow-x: hidden;
+  width: 100%;
+}


### PR DESCRIPTION
## Summary
- Enforce `max-width: var(--container-max)` for both `.container` and `.sf-menu__submenu`
- Hide horizontal overflow and replace `width:100vw` on `.sf-menu__submenu`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6354f071c832d82a78a4c62aa2d24