### PR TITLE
Allow mega menu items to shrink

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -25,7 +25,7 @@
   }
   .sf-header .sf-menu-item-parent[data-mega="categorii"] .sf-menu-submenu__items{
     display:grid;
-    grid-template-columns:repeat(auto-fill,minmax(220px,1fr));
+    grid-template-columns:repeat(auto-fill,minmax(0,1fr));
     gap:1.5rem;
     margin:0;
   }
@@ -52,4 +52,8 @@
     flex:0 0 auto;
     width:auto;
   }
+}
+
+li.sf__menu-item-level2{
+  flex:0 1 auto;
 }


### PR DESCRIPTION
## Summary
- Let mega-menu grid columns shrink by using `minmax(0,1fr)`
- Allow level-2 menu items to shrink with `flex:0 1 auto`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a63854abf4832d967a0a673d34ead6