### PR TITLE
Add bottom padding to mega menu

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -226,9 +226,10 @@
 }
 
 @media (min-width: 1024px) {
-  /* Rounded bottom corners on scrollable Categorii mega menu panel */
+  /* Rounded bottom corners and extra bottom padding on scrollable Categorii mega menu panel */
   .sf-header .sf-menu-item-parent[data-mega="categorii"] .sf-menu-submenu__content {
     border-bottom-left-radius: 5px;
     border-bottom-right-radius: 5px;
+    padding-bottom: 2rem;
   }
 }

--- a/assets/custom.css.liquid
+++ b/assets/custom.css.liquid
@@ -227,10 +227,11 @@
 }
 
 @media (min-width: 1024px) {
-  /* Rounded bottom corners on scrollable Categorii mega menu panel */
+  /* Rounded bottom corners and extra bottom padding on scrollable Categorii mega menu panel */
   .sf-header .sf-menu-item-parent[data-mega="categorii"] .sf-menu-submenu__content {
     border-bottom-left-radius: 5px;
     border-bottom-right-radius: 5px;
+    padding-bottom: 2rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- add bottom padding to Categorii mega menu panel to avoid visual overflow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a62d3a2aa0832d9b8f421db786f518