### PR TITLE
Fix scroll to top button state handling

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -2895,6 +2895,13 @@ function initScrollTop() {
 
   if (scrollTopButton) {
     scrollTopButton.addEventListener('click', scrollToTop);
+    scrollTopButton.addEventListener('click', function (e) {
+      if (typeof e.detail === 'number' && e.detail > 0) {
+        scrollTopButton.blur();
+      }
+    }, {
+      passive: true
+    });
     window.addEventListener('scroll', function () {
       const method = window.scrollY > 100 ? 'add' : 'remove';
       scrollTopButton.classList[method]('opacity-100');

--- a/snippets/scroll-top-button.liquid
+++ b/snippets/scroll-top-button.liquid
@@ -18,9 +18,37 @@
         height: 14px;
       }
     }
+    /* State logic strictly for the scroll-to-top button */
+    #scroll-to-top-button.sf__btn.sf__btn-primary {
+      /* default (idle) = red */
+      background-color: var(--color-btn-bg);
+      border-color: var(--color-btn-bg);
+      color: var(--color-btn-text);
+    }
+
+    /* hover & active = black */
+    #scroll-to-top-button.sf__btn.sf__btn-primary:hover,
+    #scroll-to-top-button.sf__btn.sf__btn-primary:active {
+      background-color: var(--color-btn-bg-hover);
+      border-color: var(--color-btn-bg-hover);
+      color: var(--color-btn-text-hover, #fff);
+    }
+
+    /* IMPORTANT: focused-but-not-active stays red (prevents "stuck black") */
+    #scroll-to-top-button.sf__btn.sf__btn-primary:focus {
+      background-color: var(--color-btn-bg);
+      border-color: var(--color-btn-bg);
+      color: var(--color-btn-text);
+    }
+
+    /* Accessible focus ring only when focus is visible (keyboard users) */
+    #scroll-to-top-button:focus-visible {
+      outline: 2px solid var(--color-primary-darker);
+      outline-offset: 2px;
+    }
   {% endstyle %}
-<div id="scroll-to-top-target" class="w-0 h-0 invisible opacity-0"></div>
-<button
+  <div id="scroll-to-top-target" class="w-0 h-0 invisible opacity-0"></div>
+  <button
   id="scroll-to-top-button"
   class="sf__btn btn-scroll-top sf__btn-primary fixed z-50 bottom-[86px] items-center justify-center right-4 opacity-0 transition-opacity"
 >


### PR DESCRIPTION
## Summary
- scope scroll-to-top button styles so hover/active turn black while idle stays red
- release focus after pointer clicks to avoid stuck :focus styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7255d53ac832d9a8335aa841317ce