### PR TITLE
feat: use white accordion arrows in footer

### DIFF
--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -3,6 +3,18 @@
   {% render 'footer-design', container: section.settings.container %}
 </footer>
 
+{% comment %}Arrows in footer — force white icon only in footer{% endcomment %}
+<style>
+  /* Scope strict la footer — nu afectează alte acordeoane */
+  .sf-footer {
+    --arrow-down-url: var(--arrow-down-white-url);
+  }
+
+  .sf-footer .sf__accordion-item .sf__accordion-button::after {
+    background-image: var(--arrow-down-white-url);
+  }
+</style>
+
 {% schema %}
 {
   "name": "Footer",


### PR DESCRIPTION
## Summary
- ensure footer accordion arrows use the white icon

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a730563718832d9e08655368995ec9