### PR TITLE
Fix footer hover underline

### DIFF
--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -15,6 +15,81 @@
   }
 </style>
 
+{% comment %}Footer links — keep only a short white underline under text on hover{% endcomment %}
+<style>
+  /* Bază: linkurile din footer rămân albe, fără underline implicit */
+  .sf-footer .sf__footer-block-content a {
+    color: var(--color-footer-text, #fff);
+    text-decoration: none;
+  }
+
+  /* Hover: underline nativ, alb, doar sub text */
+  .sf-footer .sf__footer-block-content a:hover {
+    color: var(--color-footer-text, #fff);
+    text-decoration: underline;
+    text-decoration-color: currentColor;
+    text-underline-offset: 3px;
+    text-decoration-thickness: 1px;
+  }
+
+  /* Neutralizează implementările alternative de underline pe linkuri (evită linia lungă) */
+  .sf-footer .sf__footer-block-content a,
+  .sf-footer .sf__footer-block-content a:hover {
+    background-image: none !important;   /* oprește underline pe background */
+    border-bottom: 0 !important;         /* oprește underline pe border al linkului */
+  }
+
+  /* IMPORTANT: nu schimba separatorul <li> la hover; păstrează culoarea implicită a temei */
+  .sf-footer .sf__footer-block-content li:hover {
+    border-bottom-color: var(--color-border);
+  }
+
+  /* Dacă există utilitare gen hover:text-black pe linkuri din footer, le neutralizăm local */
+  .sf-footer .sf__footer-block-content a:hover[class*="hover:text-"] {
+    color: var(--color-footer-text, #fff) !important;
+  }
+</style>
+
+{% comment %}Footer — neutralizeaza pseudo-underline-ul negru al .hover-underline si pastreaza doar underline alb nativ{% endcomment %}
+<style>
+  /* 1) Dezactiveaza pseudo-elementul care deseneaza linia neagra pe toata latimea */
+  .sf-footer .sf__footer-block-content .hover-underline a::after {
+    /* anulam complet "fake underline"-ul */
+    content: none !important;
+    background: none !important;
+    width: 0 !important;
+    height: 0 !important;
+  }
+
+  /* 2) Impiedica .hover-underline sa intoarca textul pe negru cand e hovered LI-ul */
+  .sf-footer .sf__footer-block-content .hover-underline:hover > a {
+    color: var(--color-footer-text, #fff) !important;
+    text-decoration-color: currentColor;
+  }
+
+  /* 3) Logica underline-ului ramane nativ, scurt, sub text (alb) */
+  .sf-footer .sf__footer-block-content a {
+    color: var(--color-footer-text, #fff);
+    text-decoration: none;
+  }
+  .sf-footer .sf__footer-block-content a:hover {
+    color: var(--color-footer-text, #fff);
+    text-decoration: underline;
+    text-decoration-color: currentColor;
+    text-underline-offset: 3px;
+    text-decoration-thickness: 1px;
+  }
+
+  /* 4) Pastram separatorul LI neschimbat la hover */
+  .sf-footer .sf__footer-block-content li:hover {
+    border-bottom-color: var(--color-border);
+  }
+
+  /* 5) Neutralizeaza utilitare globale gen hover:text-black pe linkuri din footer */
+  .sf-footer .sf__footer-block-content a:hover[class*="hover:text-"] {
+    color: var(--color-footer-text, #fff) !important;
+  }
+</style>
 {% schema %}
 {
   "name": "Footer",


### PR DESCRIPTION
## Summary
- neutralize `.hover-underline` pseudo-element in footer so only short white native underline appears on hover
- keep footer link text and separators white while cancelling utility classes that switch to black

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a73238f4a8832da32cd3a613c25f22