### PR TITLE
fix: remove long black underline for footer links

### DIFF
--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -1,1 +1,340 @@
-{"current":{"th_key":"BR843 CPX421 IG3JJ 10ZVZ 4XC31 VTM45 KKD332","favicon":"shopify:\/\/shop_images\/favicon-egross-t.png","double_qty_btn_label":"Adauga inca {min_qty}","container_width":1200,"container_fluid_width":1280,"container_fluid_offset":65,"color_primary":"#000000","color_main_bg":"#ffffff","color_field_bg":"#ffffff","color_body_text":"#000000","color_heading_text":"#000000","color_sub_text":"#666666","color_text_link_hover":"#dfdfdf","color_btn_bg":"#de0b0b","color_btn_bg_hover":"#000000","product_title_color":"#000000","prod_sale_price_color":"#666666","prod_regular_price_color":"#000000","prod_type_color":"#666666","prod_desc_color":"#666666","color_annoucement_bg":"#0d8329","color_topbar_bg":"#de0b0b","color_topbar_text":"#ffffff","color_header_bg":"#ffffff","color_header_link":"#000000","color_header_transparent":"#000000","bg_cart_wishlist_count":"#de0b0b","color_menu_bar_bg":"#de0b0b","color_menu_bar_text":"#f8f8f8","color_footer_bg":"#212121","color_footer_text":"#ffffff","color_footer_subtext":"#ffffff","color_footer_link":"#ffffff","color_footer_link_hover":"#fffafa","color_footer_bg_mb":"#212121","color_footer_bottom_bg":"#212121","color_footer_bottom_text":"#ffffff","color_footer_bottom_bg_mb":"#212121","color_border":"#dedede","img_overlay_opacity":20,"tooltip_background_color":"#000000","type_base_font":"montserrat_n5","use_custom_font_body":false,"custom_body_font":"https:\/\/cdn.shopify.com\/s\/files\/1\/0561\/2742\/2636\/files\/Jost-Regular.ttf?v=1618297125@400\nhttps:\/\/cdn.shopify.com\/s\/files\/1\/0561\/2742\/2636\/files\/Jost-Medium.ttf?v=1618297125@500\nhttps:\/\/cdn.shopify.com\/s\/files\/1\/0561\/2742\/2636\/files\/Jost-SemiBold.ttf?v=1618297125@600","custom_body_weight":"400","type_base_size":16,"type_base_line_height":23,"type_header_font":"montserrat_n8","use_custom_font_heading":false,"custom_heading_font":"https:\/\/cdn.shopify.com\/s\/files\/1\/0561\/2742\/2636\/files\/Jost-Regular.ttf?v=1618297125@400\nhttps:\/\/cdn.shopify.com\/s\/files\/1\/0561\/2742\/2636\/files\/Jost-Medium.ttf?v=1618297125@500\nhttps:\/\/cdn.shopify.com\/s\/files\/1\/0561\/2742\/2636\/files\/Jost-SemiBold.ttf?v=1618297125@600","custom_heading_weight":"500","type_header_base_size":40,"type_header_spacing":0,"btn_weight":"500","pcard_layout":"4","pcard_alignment":"left","pcard_image_ratio":"1\/1","show_swatch_option":false,"pcard_option_name":"culoare,marime,dimensiuni,","show_cart_button":true,"show_wishlist_button":true,"show_compare_button":false,"show_countdown":false,"on_sale_badge":"show_percentage","show_review_badge":true,"show_vendor":false,"uppercase_prd_name":true,"pcard_title_line_clamp":"1","variant_option_design_default":"image","variant_option_title1":"Dimensiuni","variant_option_design1":"button","variant_option_display_name1":"Selecteaza Dimensiune","variant_option_title2":"Culoare","variant_option_design2":"image","variant_option_display_name2":"Selecteaza Culoare","variant_option_design3":"color","product_colors":"red: #FF6961,\nyellow: #FDDA76,\nnegru: #000000,\nblack band: #000000,\nalbastru: #8DB4D2,\ngreen: #C1E1C1,\npurple: #B19CD9,\nsilver: #EEEEEF,\nalb: #FFFFFF,\nbrown: #836953,\nlight brown: #B5651D,\ndark turquoise: #23cddc,\norange: #FFB347,\ntan: #E9D1BF,\nviolet: #B490B0,\npink: #FFD1DC,\ngrey: #E0E0E0,\nsky: #96BDC6,\npale leaf: #CCD4BF,\nlight blue: #b1c5d4,\ndark grey: #aca69f,\nbeige: #EBE6DB,\nbeige band: #EED9C4,\ndark blue: #063e66,\ncream: #FFFFCC,\nlight pink: #FBCFCD,\nmint: #bedce3,\ndark gray: #3A3B3C,\nrosy brown: #c4a287,\nlight grey:#D3D3D3,\ncopper: #B87333,\nrose gold: #ECC5C0,\nnight blue: #151B54,\ncoral: #FF7F50,\nlight purple: #C6AEC7","filter_color1":"Gingham","filter_color2":"flannel","article_show_date":false,"article_show_excerpt":true,"article_show_button":true,"share_facebook":true,"share_pinterest":true,"contact_phone_number":"0729 554 378","contact_email":"egross.romania@gmail.com","find_store":"contact","social_twitter_link":"","social_twitter_label":"","social_facebook_link":"https:\/\/www.facebook.com\/en.grosss\/","social_facebook_label":"URMARESTE-NE:","social_pinterest_link":"","social_pinterest_label":"","social_instagram_link":"","social_instagram_label":"","social_whatsapp_link":"","cart_drawer_show_accelerated_button":true,"discount_code_enable":true,"cart_estimate_shipping":false,"default_country_estimate_shipping":"RO","search_by_tag":true,"search_by_body":true,"search_unavailable_products":"LAST","wishlist_page":"lista-dorinte","agree_text":"<p>Sunt de acord cu <a href=\"\/pages\/termeni-conditii\" target=\"_blank\" title=\"Termeni & Conditii\">Termenii si Conditiile<\/a><\/p>","show_agree_on_product":false,"show_cookie_consent":true,"cookie_consent_message":"Acest site folosește cookie-uri. Continuarea navigării reprezintă acceptul dvs. pentru această folosință. Pentru mai multe detalii privind gestionarea preferințelor privind cookie-uri, vedeți Politica de utillizare cookie-uri","cookie_consent_allow":"Permite Cookies","cookie_consent_decline":"Refuza","cookie_consent_learnmore":"Detalii","cookie_consent_learnmore_link":"","cookie_consent_placement":"bottom-left","cookie_consent_theme":"black","custom_css":".sf-topbar {\n  border-color: #eee;\n}\n[id$=\"16225125199f82d8fe\"] .section-my {\n  padding-top: 45px;\n  padding-bottom: 45px;\n  margin-bottom: 0;\n  margin-top: 0;\n}\n[id$=\"16225125199f82d8fe\"] {\n  border-top: 1px solid #eee;\n}\n.sf__font-normal {\n  font-weight: 400;\n}\n[id$=\"16225316461d1cff80\"]\n  .collection-card__info\n  h3\n  a {\n  font-weight: 400;\n  font-size: 24px;\n  line-height: 34px;\n  margin-bottom: 4px;\n}\n[id$=\"16225316461d1cff80\"]\n  .collection-card__info\n  p {\n  color: #666;\n}\n[id$=\"16225125199f82d8fe\"] .sf-icon-box__text h3 {\n  line-height: 26px;\n  font-size: 20px;\n  font-weight: 500;\n}\n@media (min-width: 1536px) {\n  [id$=\"1621243260e1af0c20\"] .slide__block-title {\n    font-size: 100px;\n    line-height: 95px;\n  }\n}\n@media (max-width: 576px) {\n  [id$=\"1621243260e1af0c20\"] a.sf__mobile-button,\n  [id$=\"162251092958fcda7c\"] .sf__btn-primary,\n  [id$=\"162251092958fcda7c\"] .sf__btn-secondary {\n    width: 100%;\n  }\n  [id$=\"16225316461d1cff80\"] .section__heading {\n    text-align: center;\n  }\n  [id$=\"16225316461d1cff80\"]\n    .collection-card__info\n    h3\n    a {\n    font-weight: 500;\n  }\n  [id$=\"16225316461d1cff80\"]\n    .collection-card__info\n    p {\n    font-size: 14px;\n    line-height: 20px;\n  }\n  [id$=\"16225125199f82d8fe\"] .sf-icon-box__text h3 {\n    font-size: 18px;\n    margin-bottom: 2px;\n  }\n}","review_app":"lai_reviews","currency_code_enabled":false,"checkout_logo_image":"shopify:\/\/shop_images\/Bunny_Shop_1.png","show_variant_swatch_image":true,"bg_cart_count":"#da3f3f","sections":{"header":{"type":"header","blocks":{"5e153016-a9d7-46c9-a10e-30d16446793d":{"type":"topbar","settings":{"show_divider":true,"show_phone_numb":true,"show_email":false,"show_social_links":true,"show_stores_page":false,"show_currency_switcher":true,"show_country_selector":false,"show_language_switcher":false,"alert_message":"<span><a class=\"sf__text-link  ml-1 underline\" href=\"#\"><\/a><span><\/span><\/span>"}},"5b9aec5f-b955-4765-9a87-1962d613e909":{"type":"custom_html","disabled":true,"settings":{"heading":"Home","container":"container","html":""}},"a820a1bc-dfc4-4e61-8c8a-de23659759a6":{"type":"banner","disabled":true,"settings":{"heading":"Shop","container":"w-full","banner_style":"outside","banner_link":"","banner_title":"The New - Season Shoes Edit","banner_desc":"","banner_button_text":"Shop now"}},"31481022-f698-4968-bf06-3c24f36b09e7":{"type":"product-list","disabled":true,"settings":{"heading":"Products","container":"container-fluid","stretch_width":false,"collection":"best-sellers","limit":6,"columns":2}},"ea723308-92c0-42ae-a45d-aede426d8cdd":{"type":"custom_html","disabled":true,"settings":{"heading":"Features","container":"inherit","html":""}}},"block_order":["5e153016-a9d7-46c9-a10e-30d16446793d","5b9aec5f-b955-4765-9a87-1962d613e909","a820a1bc-dfc4-4e61-8c8a-de23659759a6","31481022-f698-4968-bf06-3c24f36b09e7","ea723308-92c0-42ae-a45d-aede426d8cdd"],"custom_css":[],"settings":{"header_design":"logo-left__2l","container":"container","header_sticky":true,"transparent_on_top":false,"logo_text":"EGROSS.RO","logo":"shopify:\/\/shop_images\/egross-logo.png","logo_svg":"","logo_mobile_svg":"","logo_transparent_svg":"","logo_max_width":285,"sticky_logo_max_width":145,"mobile_logo_max_width":110,"main_menu":"main-menu","secondary_menu":"","mobile_menu":"","uppercase_parent_level":false,"search":"show_full","show_account_icon":true,"show_cart_icon":true,"show_wishlist_icon":true,"show_compare_icon":false,"show_currency_switcher":false,"show_country_selector":false,"show_language_switcher":false}},"footer":{"type":"footer","blocks":{"49e72833-c68f-4a7b-ab64-3ef0cae99bcb":{"type":"menu","settings":{"menu":"footer","title":"Informatii","width":"25%","order_first":false,"open_default":false}},"7ebc2f78-975b-4a81-b874-103c3355a866":{"type":"menu","settings":{"menu":"main-menu","title":"","width":"25%","order_first":false,"open_default":false}},"93571032-b171-4c66-8b3e-96cd91946363":{"type":"our_store","settings":{"title":"Magazinul Nostru","description":"<p>Fa-ne o vizita <a href=\"\/pages\/contact\" title=\"Contact\"><span style=\"text-decoration:underline\">Vezi Locatia<\/span><\/a><\/p>","show_email":true,"show_phone":true,"show_socials_link":false,"width":"25%","order_first":false,"open_default":false}},"7b0bf4c6-3873-4222-b8d6-ce009e710078":{"type":"newsletter","disabled":true,"settings":{"title":"Aboneaza-te","description":"Adauga adresa de email si te vom contacta cand avem promotii sau cand aducem produse noi","email_placeholder":"Introdu E-mail","form_style":"bordered","show_social":false,"show_agree_checkbox":false,"width":"25%","order_first":true,"open_default":true}},"c623bcc5-6445-4c76-ad7e-5e61d8510105":{"type":"custom_html","settings":{"title":"ANPC","html":"<a href=\"https:\/\/ec.europa.eu\/consumers\/odr\">\n<img alt=\"sol\" src=\"https:\/\/cdn.shopify.com\/s\/files\/1\/0576\/1449\/9929\/files\/2-0728014.png?v=1668116634\"\n         width=250\" height=\"90\">\n\n<a href=\"https:\/\/anpc.ro\/ce-este-sal\/\">\n<img alt=\"sol\" src=\"https:\/\/cdn.shopify.com\/s\/files\/1\/0576\/1449\/9929\/files\/1-0728014.png?v=1668116634\"\n         width=250\" height=\"90\">","width":"25%","order_first":false,"open_default":false}}},"block_order":["49e72833-c68f-4a7b-ab64-3ef0cae99bcb","7ebc2f78-975b-4a81-b874-103c3355a866","93571032-b171-4c66-8b3e-96cd91946363","7b0bf4c6-3873-4222-b8d6-ce009e710078","c623bcc5-6445-4c76-ad7e-5e61d8510105"],"settings":{"design":"footer-1","container":"container-fluid","bordered":true,"copyright":"<a href=\"https:\/\/shopify.pxf.io\/e4MWo1\"> © Shopify <\/a>","show_country_selector":false,"show_currency_selector":false,"show_language_selector":false,"show_social_links":false,"show_payment_icons":false,"payment_icons_width":300}},"annoucement":{"type":"annoucement","settings":{"show_announcement":false,"homepage_only":false,"show_close":true,"message":"<span class=\"font-medium\" style=\"font-size: 15px;\">Banner <\/span>","message_link":"https:\/\/ecomschool.ro\/tema-shopify-concept-pro","show_divider":false}},"mobile-sticky-bar":{"type":"mobile-sticky-bar","settings":{"show_mobile_sticky":true,"show_home_icon":true,"show_collection_icon":true,"show_cart_icon":true,"show_search_icon":true,"show_account_icon":false,"show_wishlist_icon":false}}},"content_for_index":[]},"platform_customizations":{"custom_css":[]}}
+/*
+ * ------------------------------------------------------------
+ * IMPORTANT: The contents of this file are auto-generated.
+ *
+ * This file may be updated by the Shopify admin theme editor
+ * or related systems. Please exercise caution as any changes
+ * made to this file may be overwritten.
+ * ------------------------------------------------------------
+ */
+{
+  "current": {
+    "th_key": "BR843 CPX421 IG3JJ 10ZVZ 4XC31 VTM45 KKD332",
+    "favicon": "shopify://shop_images/favicon-egross-t.png",
+    "double_qty_btn_label": "Adauga inca {min_qty}",
+    "container_width": 1200,
+    "container_fluid_width": 1280,
+    "container_fluid_offset": 65,
+    "color_primary": "#000000",
+    "color_main_bg": "#ffffff",
+    "color_field_bg": "#ffffff",
+    "color_body_text": "#000000",
+    "color_heading_text": "#000000",
+    "color_sub_text": "#666666",
+    "color_text_link_hover": "#dfdfdf",
+    "color_btn_bg": "#de0b0b",
+    "color_btn_bg_hover": "#000000",
+    "product_title_color": "#000000",
+    "prod_sale_price_color": "#666666",
+    "prod_regular_price_color": "#000000",
+    "prod_type_color": "#666666",
+    "prod_desc_color": "#666666",
+    "color_annoucement_bg": "#0d8329",
+    "color_topbar_bg": "#de0b0b",
+    "color_topbar_text": "#ffffff",
+    "color_header_bg": "#ffffff",
+    "color_header_link": "#000000",
+    "color_header_transparent": "#000000",
+    "bg_cart_wishlist_count": "#de0b0b",
+    "color_menu_bar_bg": "#de0b0b",
+    "color_menu_bar_text": "#f8f8f8",
+    "color_footer_bg": "#212121",
+    "color_footer_text": "#ffffff",
+    "color_footer_subtext": "#ffffff",
+    "color_footer_link": "#ffffff",
+    "color_footer_link_hover": "#fffafa",
+    "color_footer_bg_mb": "#212121",
+    "color_footer_bottom_bg": "#212121",
+    "color_footer_bottom_text": "#ffffff",
+    "color_footer_bottom_bg_mb": "#212121",
+    "color_border": "#dedede",
+    "img_overlay_opacity": 20,
+    "tooltip_background_color": "#000000",
+    "type_base_font": "montserrat_n5",
+    "use_custom_font_body": false,
+    "custom_body_font": "https://cdn.shopify.com/s/files/1/0561/2742/2636/files/Jost-Regular.ttf?v=1618297125@400\nhttps://cdn.shopify.com/s/files/1/0561/2742/2636/files/Jost-Medium.ttf?v=1618297125@500\nhttps://cdn.shopify.com/s/files/1/0561/2742/2636/files/Jost-SemiBold.ttf?v=1618297125@600",
+    "custom_body_weight": "400",
+    "type_base_size": 16,
+    "type_base_line_height": 23,
+    "type_header_font": "montserrat_n8",
+    "use_custom_font_heading": false,
+    "custom_heading_font": "https://cdn.shopify.com/s/files/1/0561/2742/2636/files/Jost-Regular.ttf?v=1618297125@400\nhttps://cdn.shopify.com/s/files/1/0561/2742/2636/files/Jost-Medium.ttf?v=1618297125@500\nhttps://cdn.shopify.com/s/files/1/0561/2742/2636/files/Jost-SemiBold.ttf?v=1618297125@600",
+    "custom_heading_weight": "500",
+    "type_header_base_size": 40,
+    "type_header_spacing": 0,
+    "btn_weight": "500",
+    "pcard_layout": "4",
+    "pcard_alignment": "left",
+    "pcard_image_ratio": "1/1",
+    "show_swatch_option": false,
+    "pcard_option_name": "culoare,marime,dimensiuni,",
+    "show_cart_button": true,
+    "show_wishlist_button": true,
+    "show_compare_button": false,
+    "show_countdown": false,
+    "on_sale_badge": "show_percentage",
+    "show_review_badge": true,
+    "show_vendor": false,
+    "uppercase_prd_name": true,
+    "pcard_title_line_clamp": "1",
+    "variant_option_design_default": "image",
+    "variant_option_title1": "Dimensiuni",
+    "variant_option_design1": "button",
+    "variant_option_display_name1": "Selecteaza Dimensiune",
+    "variant_option_title2": "Culoare",
+    "variant_option_design2": "image",
+    "variant_option_display_name2": "Selecteaza Culoare",
+    "variant_option_design3": "color",
+    "product_colors": "red: #FF6961,\nyellow: #FDDA76,\nnegru: #000000,\nblack band: #000000,\nalbastru: #8DB4D2,\ngreen: #C1E1C1,\npurple: #B19CD9,\nsilver: #EEEEEF,\nalb: #FFFFFF,\nbrown: #836953,\nlight brown: #B5651D,\ndark turquoise: #23cddc,\norange: #FFB347,\ntan: #E9D1BF,\nviolet: #B490B0,\npink: #FFD1DC,\ngrey: #E0E0E0,\nsky: #96BDC6,\npale leaf: #CCD4BF,\nlight blue: #b1c5d4,\ndark grey: #aca69f,\nbeige: #EBE6DB,\nbeige band: #EED9C4,\ndark blue: #063e66,\ncream: #FFFFCC,\nlight pink: #FBCFCD,\nmint: #bedce3,\ndark gray: #3A3B3C,\nrosy brown: #c4a287,\nlight grey:#D3D3D3,\ncopper: #B87333,\nrose gold: #ECC5C0,\nnight blue: #151B54,\ncoral: #FF7F50,\nlight purple: #C6AEC7",
+    "filter_color1": "Gingham",
+    "filter_color2": "flannel",
+    "article_show_date": false,
+    "article_show_excerpt": true,
+    "article_show_button": true,
+    "share_facebook": true,
+    "share_pinterest": true,
+    "contact_phone_number": "0729 554 378",
+    "contact_email": "egross.romania@gmail.com",
+    "find_store": "contact",
+    "social_twitter_link": "",
+    "social_twitter_label": "",
+    "social_facebook_link": "https://www.facebook.com/en.grosss/",
+    "social_facebook_label": "URMARESTE-NE:",
+    "social_pinterest_link": "",
+    "social_pinterest_label": "",
+    "social_instagram_link": "",
+    "social_instagram_label": "",
+    "social_whatsapp_link": "",
+    "cart_drawer_show_accelerated_button": true,
+    "discount_code_enable": true,
+    "cart_estimate_shipping": false,
+    "default_country_estimate_shipping": "RO",
+    "search_by_tag": true,
+    "search_by_body": true,
+    "search_unavailable_products": "LAST",
+    "wishlist_page": "lista-dorinte",
+    "agree_text": "<p>Sunt de acord cu <a href=\"/pages/termeni-conditii\" target=\"_blank\" title=\"Termeni & Conditii\">Termenii si Conditiile</a></p>",
+    "show_agree_on_product": false,
+    "show_cookie_consent": true,
+    "cookie_consent_message": "Acest site folosește cookie-uri. Continuarea navigării reprezintă acceptul dvs. pentru această folosință. Pentru mai multe detalii privind gestionarea preferințelor privind cookie-uri, vedeți Politica de utillizare cookie-uri",
+    "cookie_consent_allow": "Permite Cookies",
+    "cookie_consent_decline": "Refuza",
+    "cookie_consent_learnmore": "Detalii",
+    "cookie_consent_learnmore_link": "",
+    "cookie_consent_placement": "bottom-left",
+    "cookie_consent_theme": "black",
+    "custom_css": ".sf-topbar {\n  border-color: #eee;\n}\n[id$=\"16225125199f82d8fe\"] .section-my {\n  padding-top: 45px;\n  padding-bottom: 45px;\n  margin-bottom: 0;\n  margin-top: 0;\n}\n[id$=\"16225125199f82d8fe\"] {\n  border-top: 1px solid #eee;\n}\n.sf__font-normal {\n  font-weight: 400;\n}\n[id$=\"16225316461d1cff80\"]\n  .collection-card__info\n  h3\n  a {\n  font-weight: 400;\n  font-size: 24px;\n  line-height: 34px;\n  margin-bottom: 4px;\n}\n[id$=\"16225316461d1cff80\"]\n  .collection-card__info\n  p {\n  color: #666;\n}\n[id$=\"16225125199f82d8fe\"] .sf-icon-box__text h3 {\n  line-height: 26px;\n  font-size: 20px;\n  font-weight: 500;\n}\n@media (min-width: 1536px) {\n  [id$=\"1621243260e1af0c20\"] .slide__block-title {\n    font-size: 100px;\n    line-height: 95px;\n  }\n}\n@media (max-width: 576px) {\n  [id$=\"1621243260e1af0c20\"] a.sf__mobile-button,\n  [id$=\"162251092958fcda7c\"] .sf__btn-primary,\n  [id$=\"162251092958fcda7c\"] .sf__btn-secondary {\n    width: 100%;\n  }\n  [id$=\"16225316461d1cff80\"] .section__heading {\n    text-align: center;\n  }\n  [id$=\"16225316461d1cff80\"]\n    .collection-card__info\n    h3\n    a {\n    font-weight: 500;\n  }\n  [id$=\"16225316461d1cff80\"]\n    .collection-card__info\n    p {\n    font-size: 14px;\n    line-height: 20px;\n  }\n  [id$=\"16225125199f82d8fe\"] .sf-icon-box__text h3 {\n    font-size: 18px;\n    margin-bottom: 2px;\n  }\n}",
+    "review_app": "lai_reviews",
+    "currency_code_enabled": false,
+    "checkout_logo_image": "shopify://shop_images/Bunny_Shop_1.png",
+    "show_variant_swatch_image": true,
+    "bg_cart_count": "#da3f3f",
+    "sections": {
+      "header": {
+        "type": "header",
+        "blocks": {
+          "5e153016-a9d7-46c9-a10e-30d16446793d": {
+            "type": "topbar",
+            "settings": {
+              "show_divider": true,
+              "show_phone_numb": true,
+              "show_email": false,
+              "show_social_links": true,
+              "show_stores_page": false,
+              "show_currency_switcher": true,
+              "show_country_selector": false,
+              "show_language_switcher": false,
+              "alert_message": "<span><a class=\"sf__text-link  ml-1 underline\" href=\"#\"></a><span></span></span>"
+            }
+          },
+          "5b9aec5f-b955-4765-9a87-1962d613e909": {
+            "type": "custom_html",
+            "disabled": true,
+            "settings": {
+              "heading": "Home",
+              "container": "container",
+              "html": ""
+            }
+          },
+          "a820a1bc-dfc4-4e61-8c8a-de23659759a6": {
+            "type": "banner",
+            "disabled": true,
+            "settings": {
+              "heading": "Shop",
+              "container": "w-full",
+              "banner_style": "outside",
+              "banner_link": "",
+              "banner_title": "The New - Season Shoes Edit",
+              "banner_desc": "",
+              "banner_button_text": "Shop now"
+            }
+          },
+          "31481022-f698-4968-bf06-3c24f36b09e7": {
+            "type": "product-list",
+            "disabled": true,
+            "settings": {
+              "heading": "Products",
+              "container": "container-fluid",
+              "stretch_width": false,
+              "collection": "best-sellers",
+              "limit": 6,
+              "columns": 2
+            }
+          },
+          "ea723308-92c0-42ae-a45d-aede426d8cdd": {
+            "type": "custom_html",
+            "disabled": true,
+            "settings": {
+              "heading": "Features",
+              "container": "inherit",
+              "html": ""
+            }
+          }
+        },
+        "block_order": [
+          "5e153016-a9d7-46c9-a10e-30d16446793d",
+          "5b9aec5f-b955-4765-9a87-1962d613e909",
+          "a820a1bc-dfc4-4e61-8c8a-de23659759a6",
+          "31481022-f698-4968-bf06-3c24f36b09e7",
+          "ea723308-92c0-42ae-a45d-aede426d8cdd"
+        ],
+        "custom_css": [],
+        "settings": {
+          "header_design": "logo-left__2l",
+          "container": "container",
+          "header_sticky": true,
+          "transparent_on_top": false,
+          "logo_text": "EGROSS.RO",
+          "logo": "shopify://shop_images/egross-logo.png",
+          "logo_svg": "",
+          "logo_mobile_svg": "",
+          "logo_transparent_svg": "",
+          "logo_max_width": 285,
+          "sticky_logo_max_width": 145,
+          "mobile_logo_max_width": 110,
+          "main_menu": "main-menu",
+          "secondary_menu": "",
+          "mobile_menu": "",
+          "uppercase_parent_level": false,
+          "search": "show_full",
+          "show_account_icon": true,
+          "show_cart_icon": true,
+          "show_wishlist_icon": true,
+          "show_compare_icon": false,
+          "show_currency_switcher": false,
+          "show_country_selector": false,
+          "show_language_switcher": false
+        }
+      },
+      "footer": {
+        "type": "footer",
+        "blocks": {
+          "49e72833-c68f-4a7b-ab64-3ef0cae99bcb": {
+            "type": "menu",
+            "settings": {
+              "menu": "footer",
+              "title": "Informatii",
+              "width": "25%",
+              "order_first": false,
+              "open_default": false
+            }
+          },
+          "7ebc2f78-975b-4a81-b874-103c3355a866": {
+            "type": "menu",
+            "settings": {
+              "menu": "main-menu",
+              "title": "",
+              "width": "25%",
+              "order_first": false,
+              "open_default": false
+            }
+          },
+          "93571032-b171-4c66-8b3e-96cd91946363": {
+            "type": "our_store",
+            "settings": {
+              "title": "Magazinul Nostru",
+              "description": "<p><a href=\"/pages/contact\" title=\"Contact\"><span style=\"text-decoration:underline\">Vezi Locatia</span></a></p>",
+              "show_email": true,
+              "show_phone": true,
+              "show_socials_link": false,
+              "width": "25%",
+              "order_first": false,
+              "open_default": false
+            }
+          },
+          "7b0bf4c6-3873-4222-b8d6-ce009e710078": {
+            "type": "newsletter",
+            "disabled": true,
+            "settings": {
+              "title": "Aboneaza-te",
+              "description": "Adauga adresa de email si te vom contacta cand avem promotii sau cand aducem produse noi",
+              "email_placeholder": "Introdu E-mail",
+              "form_style": "bordered",
+              "show_social": false,
+              "show_agree_checkbox": false,
+              "width": "25%",
+              "order_first": true,
+              "open_default": true
+            }
+          },
+          "c623bcc5-6445-4c76-ad7e-5e61d8510105": {
+            "type": "custom_html",
+            "settings": {
+              "title": "ANPC",
+              "html": "<a href=\"https://ec.europa.eu/consumers/odr\">\n<img alt=\"sol\" src=\"https://cdn.shopify.com/s/files/1/0576/1449/9929/files/2-0728014.png?v=1668116634\"\n         width=250\" height=\"90\">\n\n<a href=\"https://anpc.ro/ce-este-sal/\">\n<img alt=\"sol\" src=\"https://cdn.shopify.com/s/files/1/0576/1449/9929/files/1-0728014.png?v=1668116634\"\n         width=250\" height=\"90\">",
+              "width": "25%",
+              "order_first": false,
+              "open_default": false
+            }
+          }
+        },
+        "block_order": [
+          "49e72833-c68f-4a7b-ab64-3ef0cae99bcb",
+          "7ebc2f78-975b-4a81-b874-103c3355a866",
+          "93571032-b171-4c66-8b3e-96cd91946363",
+          "7b0bf4c6-3873-4222-b8d6-ce009e710078",
+          "c623bcc5-6445-4c76-ad7e-5e61d8510105"
+        ],
+        "settings": {
+          "design": "footer-1",
+          "container": "container-fluid",
+          "bordered": true,
+          "copyright": "<a href=\"https://shopify.pxf.io/e4MWo1\"> © Shopify </a>",
+          "show_country_selector": false,
+          "show_currency_selector": false,
+          "show_language_selector": false,
+          "show_social_links": false,
+          "show_payment_icons": false,
+          "payment_icons_width": 300
+        }
+      },
+      "annoucement": {
+        "type": "annoucement",
+        "settings": {
+          "show_announcement": false,
+          "homepage_only": false,
+          "show_close": true,
+          "message": "<span class=\"font-medium\" style=\"font-size: 15px;\">Banner </span>",
+          "message_link": "https://ecomschool.ro/tema-shopify-concept-pro",
+          "show_divider": false
+        }
+      },
+      "mobile-sticky-bar": {
+        "type": "mobile-sticky-bar",
+        "settings": {
+          "show_mobile_sticky": true,
+          "show_home_icon": true,
+          "show_collection_icon": true,
+          "show_cart_icon": true,
+          "show_search_icon": true,
+          "show_account_icon": false,
+          "show_wishlist_icon": false
+        }
+      }
+    },
+    "content_for_index": []
+  },
+  "platform_customizations": {
+    "custom_css": []
+  }
+}

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -14,7 +14,53 @@
     background-image: var(--arrow-down-white-url);
   }
 </style>
+{% comment %}Footer links — keep only a short white underline under text on hover{% endcomment %}
+<style>
+  /* Bază: linkurile din footer rămân albe, fără underline implicit */
+  .sf-footer .sf__footer-block-content a {
+    color: var(--color-footer-text, #fff);
+    text-decoration: none;
+  }
 
+  /* Hover: underline nativ, alb, doar sub text */
+  .sf-footer .sf__footer-block-content a:hover {
+    color: var(--color-footer-text, #fff);
+    text-decoration: underline;
+    text-decoration-color: currentColor;
+    text-underline-offset: 3px;
+    text-decoration-thickness: 1px;
+  }
+
+  /* Elimină pseudo-elementul și orice underline pe background/border (evită linia neagră) */
+  .sf-footer .sf__footer-block-content .hover-underline a::after {
+    content: none !important;
+    background: none !important;
+    width: 0 !important;
+    height: 0 !important;
+  }
+
+  /* Nu lăsa li:hover să schimbe culoarea textului */
+  .sf-footer .sf__footer-block-content .hover-underline:hover > a {
+    color: var(--color-footer-text, #fff);
+  }
+
+  /* Neutralizează implementările alternative de underline pe linkuri */
+  .sf-footer .sf__footer-block-content a,
+  .sf-footer .sf__footer-block-content a:hover {
+    background-image: none !important;
+    border-bottom: 0 !important;
+  }
+
+  /* IMPORTANT: separatorul <li> își păstrează culoarea implicită */
+  .sf-footer .sf__footer-block-content li:hover {
+    border-bottom-color: var(--color-border);
+  }
+
+  /* Neutralizează utilitare hover:text-* care pot altera culoarea */
+  .sf-footer .sf__footer-block-content a:hover[class*="hover:text-"] {
+    color: var(--color-footer-text, #fff) !important;
+  }
+</style>
 {% schema %}
 {
   "name": "Footer",

--- a/templates/page.about-us.json
+++ b/templates/page.about-us.json
@@ -1,1 +1,274 @@
-{"sections":{"main":{"type":"page-about-us","settings":{}},"custom-content":{"type":"custom-content","blocks":{"be5d2488-3c71-471f-bb75-dbccb6970cb0":{"type":"image","settings":{"image":"shopify:\/\/shop_images\/1_485206fa-6bcd-4c60-a185-bd75bda77de2.jpg","width":"100%","alignment":"center","block_custom_class":""}},"f5e88f1f-ff68-4d03-b686-0cb9fe62fab1":{"type":"text","settings":{"title":"<h4 class=\"about__block-heading\">It pains me physically to see woman victimized,<br> rendered pathetic by fashion.<\/h4>\n<p class=\"about__block-subheading\">Awkwardness gives me great comfort. I’ve never been cool, but I’ve felt cool. I’ve been in the<br> cool place, but I wasn’t really cool – I was trying to pass for hip or cool.<\/p>","subheading":"","text":"<p>A girl should be two things: classy and fabulous. I am convinced that there can be luxury in simplicity. I wanted to dress the woman who lives and works, not the woman in a painting. It’s hard to balance everything. It’s always challenging. My relationships with producers or photographers – these are relationships that took years. I can’t get sucked into that celebrity thing, because I think it’s just crass. My aim is to make the poor look rich and the rich look poor. Vanity is the healthiest thing in life. I believe that my clothes can give people a better image of themselves – that it can increase their feelings of confidence and happiness. You can hide so much behind theatrics, and I don’t need to do that any more. I don’t really know how to do casual clothes.<\/p>","width":"100%","alignment":"center","align_text":"center","text_size":"medium","text_color":"black","button_label":"","button_link":"","button_style":"sf__btn-primary","button_size":"","block_custom_class":"sf__about-block sf__about-block-text sf__about-block-text-1"}},"4e1fb14f-ef60-4693-b6a2-2b26063e1b70":{"type":"image","settings":{"image":"shopify:\/\/shop_images\/2_7ec8fac3-633a-46c9-b503-dd8b20734495.jpg","width":"50%","alignment":"center","block_custom_class":""}},"9a3a8077-de29-4141-9162-b9484d4a85f8":{"type":"html","settings":{"code":"<div class=\"sf__about-custom-list\">\n  <h3>We are proudly<br> Australian.<\/h3>\n  <ul>\n    <li>\n      <span><img src=\"https:\/\/cdn.shopify.com\/s\/files\/1\/0561\/2742\/2636\/files\/icon1.svg?v=1627616411\"><\/span>\n      <div class=\"rte\">\n          <h4>Soft Fabric<\/h4>\n          <p class=\"text-color-subtext\">Get complimentary ground shipping on every<br> order.Don’t love it? Send it back, on us.<\/p>\n      <\/div>\n    <\/li>\n    <li>\n      <span><img src=\"https:\/\/cdn.shopify.com\/s\/files\/1\/0561\/2742\/2636\/files\/icon2_daf1b6c2-ef2e-416c-ae6a-a7ddd145b6c5.svg?v=1627616411\"><\/span>\n      <div class=\"rte\">\n          <h4>Lightweight<\/h4>\n          <p class=\"text-color-subtext\">Join ConceptSGM Rewards to earn gift cards<br>\nand enjoy exclusive member benefits.<\/p>\n      <\/div>\n    <\/li>\n    <li>\n      <span><img src=\"https:\/\/cdn.shopify.com\/s\/files\/1\/0561\/2742\/2636\/files\/icon3.svg?v=1627616411\"><\/span>\n      <div class=\"rte\">\n          <h4>All Day Comfort<\/h4>\n          <p class=\"text-color-subtext\">We believe getting dressed should be the<br> easiest part of your day.<\/p>\n      <\/div>\n    <\/li>\n  <\/ul>\n<\/div>","width":"50%","block_custom_class":"sf__about-custom-html"}},"28e3ce35-e364-43f3-ba87-18b633233063":{"type":"text","settings":{"title":"<h4 class=\"about__block-heading\">The world needs to move fast to make a meaningful<br> difference in the fight against climate change.<\/h4>","subheading":"","text":"<p>A girl should be two things: classy and fabulous. I am convinced that there can be luxury in simplicity. I wanted to dress the woman who lives and works, not the woman in a painting. It’s hard to balance everything. It’s always challenging. My relationships with producers or photographers – these are relationships that took years. I can’t get sucked into that celebrity thing, because I think it’s just crass. My aim is to make the poor look rich and the rich look poor. Vanity is the healthiest thing in life. I believe that my clothes can give people a better image of themselves – that it can increase their feelings of confidence and happiness. You can hide so much behind theatrics, and I don’t need to do that any more. I don’t really know how to do casual clothes.<\/p>","width":"100%","alignment":"center","align_text":"center","text_size":"medium","text_color":"black","button_label":"","button_link":"","button_style":"sf__btn-primary","button_size":"","block_custom_class":"sf__about-block sf__about-block-text sf__about-block-text-2"}},"c6a8b57f-c54c-43f1-9771-9ea5d88a2f36":{"type":"text","settings":{"title":"Our Team","subheading":"","text":"","width":"100%","alignment":"center","align_text":"center","text_size":"medium","text_color":"black","button_label":"","button_link":"","button_style":"sf__btn-primary","button_size":"","block_custom_class":"sf__about-custom-heading"}},"859f4ef2-676f-4587-9ae8-3a19ffa439dd":{"type":"image_card","settings":{"width":"33%","content_position":"bottom_left","content_alignment":"left","text_size":"medium","text_color":"black","image":"shopify:\/\/shop_images\/3_79558a8b-6310-440f-91ee-bf86f39880db.png","link":"","title":"Edward Lindgren","subtitle":"<span class=\"text-color-subtext\">CHIEF OPERATING OFFICER<\/span>","button_label":"","button_style":"sf__btn-primary","button_size":"","block_custom_class":"sf__about-card-custom"}},"dc4597e9-ca80-4d0f-9e30-ff28c96dd3aa":{"type":"image_card","settings":{"width":"33%","content_position":"bottom_left","content_alignment":"left","text_size":"medium","text_color":"black","image":"shopify:\/\/shop_images\/4_873abf10-c96b-436a-99e7-94f2506edaf9.jpg","link":"","title":"Nado Husa","subtitle":"<span class=\"text-color-subtext\">CO-FOUNDER<\/span>","button_label":"","button_style":"sf__btn-primary","button_size":"","block_custom_class":"sf__about-card-custom"}},"a1a4a67f-c83f-4629-a006-e44f56c80bf5":{"type":"image_card","settings":{"width":"33%","content_position":"bottom_left","content_alignment":"left","text_size":"medium","text_color":"black","image":"shopify:\/\/shop_images\/5_5678f372-8f3b-4673-92a3-55b47a494056.jpg","link":"","title":"Chineze Afamefuna","subtitle":"<span class=\"text-color-subtext\">MARKETING<\/span>","button_label":"","button_style":"sf__btn-primary","button_size":"","block_custom_class":"sf__about-card-custom"}}},"block_order":["be5d2488-3c71-471f-bb75-dbccb6970cb0","f5e88f1f-ff68-4d03-b686-0cb9fe62fab1","4e1fb14f-ef60-4693-b6a2-2b26063e1b70","9a3a8077-de29-4141-9162-b9484d4a85f8","28e3ce35-e364-43f3-ba87-18b633233063","c6a8b57f-c54c-43f1-9771-9ea5d88a2f36","859f4ef2-676f-4587-9ae8-3a19ffa439dd","dc4597e9-ca80-4d0f-9e30-ff28c96dd3aa","a1a4a67f-c83f-4629-a006-e44f56c80bf5"],"settings":{"heading":"","subheading":"","description":"","header_alignment":"center","container":"container","background_color":"","gap":30,"use_scroll_mobile":false,"gap_mobile":16,"custom_class":"sf__page-about"}},"icon-box":{"type":"icon-box","blocks":{"c8a16382-6620-4bcf-ba3e-1bb9d69d5b77":{"type":"iconbox","settings":{"image":"shopify:\/\/shop_images\/1_292dc3a2-215e-4ce3-afba-7b00845e162f.png","title":"Free Shipping","description":"<p>Free Shipping for orders over £130<\/p>","link":"","button_label":"","button_link":"","button_style":"sf__btn-link","button_size":""}},"13184979-bd7f-482c-865f-60738819a029":{"type":"iconbox","settings":{"image":"shopify:\/\/shop_images\/2_4ab3f0fa-7ff5-4f0d-ba62-503f7f2fc192.png","title":"Money Guarantee","description":"<p>Within 30 days for an exchange.<\/p>","link":"","button_label":"","button_link":"","button_style":"sf__btn-link","button_size":""}},"c4cf2072-efce-4cb9-b184-14404b61e2a3":{"type":"iconbox","settings":{"image":"shopify:\/\/shop_images\/3_6044e4d8-7c0b-4f31-aac4-89baf1f7a0a9.png","title":"Online Support","description":"<p>24 hours a day, 7 days a week<\/p>","link":"","button_label":"","button_link":"","button_style":"sf__btn-link","button_size":""}},"8e15d521-c62b-4552-a64a-94ead24641e5":{"type":"iconbox","settings":{"image":"shopify:\/\/shop_images\/4_2f378f25-cac8-415a-b98b-e491bd3fd4f3.png","title":"Flexible Payment","description":"<p>Pay with Multiple Credit Cards<\/p>","link":"","button_label":"","button_link":"","button_style":"sf__btn-link","button_size":""}}},"block_order":["c8a16382-6620-4bcf-ba3e-1bb9d69d5b77","13184979-bd7f-482c-865f-60738819a029","c4cf2072-efce-4cb9-b184-14404b61e2a3","8e15d521-c62b-4552-a64a-94ead24641e5"],"settings":{"heading":"","subheading":"","description":"","header_alignment":"center","container":"container-fluid","background_color":"#ffffff","item_per_row":4,"item_gap":30,"item_gap_mobile":10,"card_style":"horizontal","image_max_width":"30px","content_alignment":"start","hover_effect":"none","enable_slider":false,"show_pagination":false,"show_navigation":false,"use_scroll_mobile":false,"use_grid_column_mb":false,"custom_class":"sf__page-about"}}},"order":["main","custom-content","icon-box"]}
+/*
+ * ------------------------------------------------------------
+ * IMPORTANT: The contents of this file are auto-generated.
+ *
+ * This file may be updated by the Shopify admin theme editor
+ * or related systems. Please exercise caution as any changes
+ * made to this file may be overwritten.
+ * ------------------------------------------------------------
+ */
+{
+  "sections": {
+    "main": {
+      "type": "page-about-us",
+      "disabled": true,
+      "settings": {}
+    },
+    "custom-content": {
+      "type": "custom-content",
+      "blocks": {
+        "be5d2488-3c71-471f-bb75-dbccb6970cb0": {
+          "type": "image",
+          "settings": {
+            "link": "",
+            "width": "100%",
+            "alignment": "center",
+            "block_custom_class": ""
+          }
+        },
+        "f5e88f1f-ff68-4d03-b686-0cb9fe62fab1": {
+          "type": "text",
+          "settings": {
+            "title": "<h4 class=\"about__block-heading\">It pains me physically to see woman victimized,<br> rendered pathetic by fashion.</h4>\n<p class=\"about__block-subheading\">Awkwardness gives me great comfort. I’ve never been cool, but I’ve felt cool. I’ve been in the<br> cool place, but I wasn’t really cool – I was trying to pass for hip or cool.</p>",
+            "subheading": "",
+            "text": "<p>A girl should be two things: classy and fabulous. I am convinced that there can be luxury in simplicity. I wanted to dress the woman who lives and works, not the woman in a painting. It’s hard to balance everything. It’s always challenging. My relationships with producers or photographers – these are relationships that took years. I can’t get sucked into that celebrity thing, because I think it’s just crass. My aim is to make the poor look rich and the rich look poor. Vanity is the healthiest thing in life. I believe that my clothes can give people a better image of themselves – that it can increase their feelings of confidence and happiness. You can hide so much behind theatrics, and I don’t need to do that any more. I don’t really know how to do casual clothes.</p>",
+            "width": "100%",
+            "alignment": "center",
+            "align_text": "center",
+            "text_size": "medium",
+            "text_color": "black",
+            "button_label": "",
+            "button_link": "",
+            "button_style": "sf__btn-primary",
+            "button_size": "",
+            "block_custom_class": "sf__about-block sf__about-block-text sf__about-block-text-1"
+          }
+        },
+        "4e1fb14f-ef60-4693-b6a2-2b26063e1b70": {
+          "type": "image",
+          "settings": {
+            "link": "",
+            "width": "50%",
+            "alignment": "center",
+            "block_custom_class": ""
+          }
+        },
+        "9a3a8077-de29-4141-9162-b9484d4a85f8": {
+          "type": "html",
+          "settings": {
+            "code": "<div class=\"sf__about-custom-list\">\n  <h3>We are proudly<br> Australian.</h3>\n  <ul>\n    <li>\n      <span><img src=\"https://cdn.shopify.com/s/files/1/0561/2742/2636/files/icon1.svg?v=1627616411\"></span>\n      <div class=\"rte\">\n          <h4>Soft Fabric</h4>\n          <p class=\"text-color-subtext\">Get complimentary ground shipping on every<br> order.Don’t love it? Send it back, on us.</p>\n      </div>\n    </li>\n    <li>\n      <span><img src=\"https://cdn.shopify.com/s/files/1/0561/2742/2636/files/icon2_daf1b6c2-ef2e-416c-ae6a-a7ddd145b6c5.svg?v=1627616411\"></span>\n      <div class=\"rte\">\n          <h4>Lightweight</h4>\n          <p class=\"text-color-subtext\">Join ConceptSGM Rewards to earn gift cards<br>\nand enjoy exclusive member benefits.</p>\n      </div>\n    </li>\n    <li>\n      <span><img src=\"https://cdn.shopify.com/s/files/1/0561/2742/2636/files/icon3.svg?v=1627616411\"></span>\n      <div class=\"rte\">\n          <h4>All Day Comfort</h4>\n          <p class=\"text-color-subtext\">We believe getting dressed should be the<br> easiest part of your day.</p>\n      </div>\n    </li>\n  </ul>\n</div>",
+            "width": "50%",
+            "block_custom_class": "sf__about-custom-html"
+          }
+        },
+        "28e3ce35-e364-43f3-ba87-18b633233063": {
+          "type": "text",
+          "settings": {
+            "title": "<h4 class=\"about__block-heading\">The world needs to move fast to make a meaningful<br> difference in the fight against climate change.</h4>",
+            "subheading": "",
+            "text": "<p>A girl should be two things: classy and fabulous. I am convinced that there can be luxury in simplicity. I wanted to dress the woman who lives and works, not the woman in a painting. It’s hard to balance everything. It’s always challenging. My relationships with producers or photographers – these are relationships that took years. I can’t get sucked into that celebrity thing, because I think it’s just crass. My aim is to make the poor look rich and the rich look poor. Vanity is the healthiest thing in life. I believe that my clothes can give people a better image of themselves – that it can increase their feelings of confidence and happiness. You can hide so much behind theatrics, and I don’t need to do that any more. I don’t really know how to do casual clothes.</p>",
+            "width": "100%",
+            "alignment": "center",
+            "align_text": "center",
+            "text_size": "medium",
+            "text_color": "black",
+            "button_label": "",
+            "button_link": "",
+            "button_style": "sf__btn-primary",
+            "button_size": "",
+            "block_custom_class": "sf__about-block sf__about-block-text sf__about-block-text-2"
+          }
+        },
+        "c6a8b57f-c54c-43f1-9771-9ea5d88a2f36": {
+          "type": "text",
+          "settings": {
+            "title": "Our Team",
+            "subheading": "",
+            "text": "",
+            "width": "100%",
+            "alignment": "center",
+            "align_text": "center",
+            "text_size": "medium",
+            "text_color": "black",
+            "button_label": "",
+            "button_link": "",
+            "button_style": "sf__btn-primary",
+            "button_size": "",
+            "block_custom_class": "sf__about-custom-heading"
+          }
+        },
+        "859f4ef2-676f-4587-9ae8-3a19ffa439dd": {
+          "type": "image_card",
+          "settings": {
+            "width": "33%",
+            "content_position": "bottom_left",
+            "content_alignment": "left",
+            "text_size": "medium",
+            "text_color": "black",
+            "link": "",
+            "title": "Edward Lindgren",
+            "subtitle": "<span class=\"text-color-subtext\">CHIEF OPERATING OFFICER</span>",
+            "button_label": "",
+            "button_style": "sf__btn-primary",
+            "button_size": "",
+            "use_content_above": false,
+            "block_custom_class": "sf__about-card-custom"
+          }
+        },
+        "dc4597e9-ca80-4d0f-9e30-ff28c96dd3aa": {
+          "type": "image_card",
+          "settings": {
+            "width": "33%",
+            "content_position": "bottom_left",
+            "content_alignment": "left",
+            "text_size": "medium",
+            "text_color": "black",
+            "link": "",
+            "title": "Nado Husa",
+            "subtitle": "<span class=\"text-color-subtext\">CO-FOUNDER</span>",
+            "button_label": "",
+            "button_style": "sf__btn-primary",
+            "button_size": "",
+            "use_content_above": false,
+            "block_custom_class": "sf__about-card-custom"
+          }
+        },
+        "a1a4a67f-c83f-4629-a006-e44f56c80bf5": {
+          "type": "image_card",
+          "settings": {
+            "width": "33%",
+            "content_position": "bottom_left",
+            "content_alignment": "left",
+            "text_size": "medium",
+            "text_color": "black",
+            "link": "",
+            "title": "Chineze Afamefuna",
+            "subtitle": "<span class=\"text-color-subtext\">MARKETING</span>",
+            "button_label": "",
+            "button_style": "sf__btn-primary",
+            "button_size": "",
+            "use_content_above": false,
+            "block_custom_class": "sf__about-card-custom"
+          }
+        }
+      },
+      "block_order": [
+        "be5d2488-3c71-471f-bb75-dbccb6970cb0",
+        "f5e88f1f-ff68-4d03-b686-0cb9fe62fab1",
+        "4e1fb14f-ef60-4693-b6a2-2b26063e1b70",
+        "9a3a8077-de29-4141-9162-b9484d4a85f8",
+        "28e3ce35-e364-43f3-ba87-18b633233063",
+        "c6a8b57f-c54c-43f1-9771-9ea5d88a2f36",
+        "859f4ef2-676f-4587-9ae8-3a19ffa439dd",
+        "dc4597e9-ca80-4d0f-9e30-ff28c96dd3aa",
+        "a1a4a67f-c83f-4629-a006-e44f56c80bf5"
+      ],
+      "settings": {
+        "heading": "",
+        "subheading": "",
+        "description": "",
+        "header_alignment": "center",
+        "container": "container",
+        "background_color": "",
+        "gap": 30,
+        "use_scroll_mobile": false,
+        "gap_mobile": 16,
+        "padding_top": 0,
+        "padding_bottom": 0,
+        "custom_class": "sf__page-about"
+      }
+    },
+    "icon-box": {
+      "type": "icon-box",
+      "blocks": {
+        "c8a16382-6620-4bcf-ba3e-1bb9d69d5b77": {
+          "type": "iconbox",
+          "settings": {
+            "image_by_url": "",
+            "title": "Free Shipping",
+            "description": "<p>Free Shipping for orders over £130</p>",
+            "link": "",
+            "button_label": "",
+            "button_link": "",
+            "button_style": "sf__btn-link",
+            "button_size": ""
+          }
+        },
+        "13184979-bd7f-482c-865f-60738819a029": {
+          "type": "iconbox",
+          "settings": {
+            "image_by_url": "",
+            "title": "Money Guarantee",
+            "description": "<p>Within 30 days for an exchange.</p>",
+            "link": "",
+            "button_label": "",
+            "button_link": "",
+            "button_style": "sf__btn-link",
+            "button_size": ""
+          }
+        },
+        "c4cf2072-efce-4cb9-b184-14404b61e2a3": {
+          "type": "iconbox",
+          "settings": {
+            "image_by_url": "",
+            "title": "Online Support",
+            "description": "<p>24 hours a day, 7 days a week</p>",
+            "link": "",
+            "button_label": "",
+            "button_link": "",
+            "button_style": "sf__btn-link",
+            "button_size": ""
+          }
+        },
+        "8e15d521-c62b-4552-a64a-94ead24641e5": {
+          "type": "iconbox",
+          "settings": {
+            "image_by_url": "",
+            "title": "Flexible Payment",
+            "description": "<p>Pay with Multiple Credit Cards</p>",
+            "link": "",
+            "button_label": "",
+            "button_link": "",
+            "button_style": "sf__btn-link",
+            "button_size": ""
+          }
+        }
+      },
+      "block_order": [
+        "c8a16382-6620-4bcf-ba3e-1bb9d69d5b77",
+        "13184979-bd7f-482c-865f-60738819a029",
+        "c4cf2072-efce-4cb9-b184-14404b61e2a3",
+        "8e15d521-c62b-4552-a64a-94ead24641e5"
+      ],
+      "disabled": true,
+      "settings": {
+        "heading": "",
+        "subheading": "",
+        "description": "",
+        "header_alignment": "center",
+        "container": "container-fluid",
+        "background_color": "#ffffff",
+        "item_per_row": 4,
+        "item_gap": 30,
+        "item_gap_mobile": 10,
+        "card_style": "horizontal",
+        "image_max_width": "30px",
+        "content_alignment": "start",
+        "hover_effect": "none",
+        "enable_slider": false,
+        "show_pagination": false,
+        "show_navigation": false,
+        "use_scroll_mobile": false,
+        "use_grid_column_mb": false,
+        "padding_top": 0,
+        "padding_bottom": 0,
+        "custom_class": "sf__page-about"
+      }
+    }
+  },
+  "order": [
+    "main",
+    "custom-content",
+    "icon-box"
+  ]
+}

--- a/templates/password.json
+++ b/templates/password.json
@@ -1,1 +1,34 @@
-{"layout":"password","sections":{"main":{"type":"password-template","settings":{}}},"order":["main"]}
+/*
+ * ------------------------------------------------------------
+ * IMPORTANT: The contents of this file are auto-generated.
+ *
+ * This file may be updated by the Shopify admin theme editor
+ * or related systems. Please exercise caution as any changes
+ * made to this file may be overwritten.
+ * ------------------------------------------------------------
+ */
+{
+  "layout": "password",
+  "sections": {
+    "main": {
+      "type": "password-template",
+      "settings": {
+        "bg_color": "#f5f1ed",
+        "show_logo": false,
+        "logo_max_width": "175",
+        "t1": "Site-ul va fi disponibil in curand",
+        "t2": "",
+        "show_n": true,
+        "n_t1": "Aboneaza-te la newsletter-ul nostru",
+        "n_t2": "Introdu adresa ta de e-mail",
+        "show_p": false,
+        "p_t1": "Enter the password to get access to the site",
+        "p_t2": "Enter Password",
+        "f_t1": "&copy; © WebArc Design Concept. Toate drepturile rezervate 2025"
+      }
+    }
+  },
+  "order": [
+    "main"
+  ]
+}


### PR DESCRIPTION
## Summary
- keep footer links white and show only short underline on hover
- disable hover-underline pseudo-element to avoid long black line

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a73238f4a8832da32cd3a613c25f22